### PR TITLE
Disabled pylint warning for missing function and class level docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ common/test/data/badges/*.png
 .vagrant/
 node_modules
 bin/
+edxapp_media_dir/
 
 ### Static assets pipeline artifacts
 *.scssc

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -13,8 +13,8 @@ disable+ =
     no-else-break,
     no-else-continue,
     useless-object-inheritance,
-    C0114, # missing-module-docstring
-    C0116, # missing-function-docstring
+    missing-module-docstring,
+    missing-function-docstring,
 
 [BASIC]
 attr-rgx = [a-z_][a-z0-9_]{2,40}$


### PR DESCRIPTION
### Disabled pylint warning for missing function and class level docstrings
