### PR TITLE
PKX-576 Hid region input and defaulted it to PK on registration

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -374,7 +374,7 @@ class RegistrationFormFactory(object):
             HttpResponse
         """
         form_desc = FormDescription("post", reverse("user_api_registration"))
-        form_desc._field_overrides['country']['defaultValue'] = "PK"
+        form_desc.override_field_properties(field_name='country', default='PK')
         self._apply_third_party_auth_overrides(request, form_desc)
 
         # Custom form fields can be added via the form set in settings.REGISTRATION_EXTENSION_FORM


### PR DESCRIPTION
### [PKX-576](https://edlyio.atlassian.net/browse/PKX-576) Hid region input and defaulted it to PK on registration


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
