### PR TITLE
PKX-542 Fixed Invalid Form Error On Mismatched Passwords

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -370,16 +370,13 @@ class PasswordResetConfirmWrapper(PasswordResetConfirmView):
 
     def _validate_password(self, password, request):
         """Matches both passwords and then validates them."""
-        err_msg = ''
         try:
             assert request.POST['new_password1'] == request.POST['new_password2']
             validate_password(password, user=self.user)
         except AssertionError:
-            err_msg = 'Passwords did not match!'
+            return self._send_template_response(request, 'Passwords did not match!')
         except ValidationError as err:
-            err_msg = ' '.join(err.messages)
-
-        return self._send_template_response(request, err_msg)
+            return self._send_template_response(request, ' '.join(err.messages))
 
     def _handle_password_reset_failure(self, response):
         form_valid = response.context_data['form'].is_valid() if response.context_data['form'] else False

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -12,7 +12,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth.views import INTERNAL_RESET_SESSION_TOKEN, PasswordResetConfirmView
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import ValidationError
-from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, HttpResponseRedirect
+from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -77,7 +77,6 @@ def get_password_reset_form():
 
     # Translators: These instructions appear on the password reset form,
     # immediately below a field meant to hold the user's email address.
-    # pylint: disable=no-member
     email_instructions = _(u"The email address you used to register with {platform_name}").format(
         platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
     )
@@ -349,13 +348,13 @@ class PasswordResetConfirmWrapper(PasswordResetConfirmView):
             return super(PasswordResetConfirmWrapper, self).dispatch(request, uidb64=self.uidb64, token=self.token,
                                                                      extra_context=self.platform_name)
 
-    def _send_template_response(self, request, err_msg):
+    def _send_template_response(self, request, err_msg: str):
         """Renders the same password change form with error message."""
         context = {
             'validlink': True,
             'form': None,
             'title': _('Password reset unsuccessful'),
-            'err_msg': _(err_msg),
+            'err_msg': _("{}".format(err_msg)),
         }
         context.update(self.platform_name)
         return TemplateResponse(

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -354,7 +354,7 @@ class PasswordResetConfirmWrapper(PasswordResetConfirmView):
             'validlink': True,
             'form': None,
             'title': _('Password reset unsuccessful'),
-            'err_msg': _("{}".format(err_msg)),
+            'err_msg': _(err_msg),
         }
         context.update(self.platform_name)
         return TemplateResponse(


### PR DESCRIPTION
### [PKX-542](https://edlyio.atlassian.net/browse/PKX-542) Fixed invalid form error displaying when mismatched passwords are entered

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
