### PR TITLE
PKX-591 Form symmetry for Marketing form

### DIFF
--- a/openedx/features/pakx/lms/overrides/forms.py
+++ b/openedx/features/pakx/lms/overrides/forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.core.validators import ValidationError
 from django.forms import ModelForm
 from django.utils.translation import ugettext as _
 
@@ -37,15 +36,3 @@ class AboutUsForm(ModelForm):
         value = self.cleaned_data['organization']
         validate_text_for_emoji(value)
         return value
-
-
-class MarketingForm(AboutUsForm):
-    phone = forms.CharField(required=False, validators=get_phone_validators(), label='Phone')
-    organization = forms.CharField(required=True, label='Organization')
-
-    def clean_organization(self):
-        org = super().clean_organization()
-
-        if org is None or org.strip() == '':
-            raise ValidationError("This field is required.")
-        return org

--- a/openedx/features/pakx/lms/overrides/views.py
+++ b/openedx/features/pakx/lms/overrides/views.py
@@ -43,7 +43,7 @@ from openedx.features.course_experience.utils import get_course_outline_block_tr
 from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
 from openedx.features.course_experience.waffle import waffle as course_experience_waffle
 from openedx.features.pakx.cms.custom_settings.models import CourseOverviewContent
-from openedx.features.pakx.lms.overrides.forms import AboutUsForm, MarketingForm
+from openedx.features.pakx.lms.overrides.forms import AboutUsForm
 from openedx.features.pakx.lms.overrides.tasks import send_contact_us_email
 from openedx.features.pakx.lms.overrides.utils import (
     add_course_progress_to_enrolled_courses,
@@ -481,7 +481,6 @@ class MarketingCampaignPage(AboutUsView):
         super().__init__(**kwargs)
         self.email_subject = 'Pakistan Against Workplace Harassment Form Data'
 
-    form_class = MarketingForm
     template_name = 'overrides/marketing_campaign.html'
     success_redirect = '/workplace-harassment/#get-started'
 


### PR DESCRIPTION
### [PKX-591](https://edlyio.atlassian.net/browse/PKX-591) Form symmetry for Marketing form

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] `Ready for review` label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable