### PR TITLE
PKX-780 Updated icons for HTML XBlock

### DIFF
--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -52,6 +52,7 @@ class HtmlBlock(
     """
     The HTML XBlock.
     """
+    icon_class = 'html'
     display_name = String(
         display_name=_("Display Name"),
         help=_("The display name for this component."),

--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 # HACK: This shouldn't be hard-coded to two types
 # OBSOLETE: This obsoletes 'type'
-CLASS_PRIORITY = ['video', 'problem']
+CLASS_PRIORITY = ['html', 'video', 'problem']
 
 
 @XBlock.needs('user', 'bookmarks')
@@ -153,6 +153,7 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
         Returns the highest priority icon class.
         """
         child_classes = set(child.get_icon_class() for child in self.get_children())
+
         new_class = 'other'
         for higher_class in CLASS_PRIORITY:
             if higher_class in child_classes:

--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -41,9 +41,12 @@
           </button>
         </li>
         % else:
+          <%
+            icon_map = {'html': 'other'}
+          %>
         % for idx, item in enumerate(items):
         <li role="presentation">
-          <button class="seq_${item['type']} inactive nav-item tab"
+          <button class="seq_${icon_map.get(item['type'], item['type'])} inactive nav-item tab"
             role="tab"
             tabindex="-1"
             aria-selected="false"
@@ -59,7 +62,7 @@
             data-href="${item['href']}"
             % endif
             id="tab_${idx}">
-            <span class="icon fa seq_${item['type']}" aria-hidden="true"></span>
+            <span class="icon fa seq_${icon_map.get(item['type'], item['type'])}" aria-hidden="true"></span>
             % if 'complete' in item:
               <span
                 class="fa fa-check-circle check-circle ${"is-hidden" if not item['complete'] else ""}"


### PR DESCRIPTION
### [PKX-780](https://edlyio.atlassian.net/browse/PKX-780) Updated icons for HTML XBlock

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
