### PR TITLE
PKX-869 Used spans instead of p tags

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -514,8 +514,8 @@ def activate_account(request, key):
             messages.info(
                 request,
                 HTML(_('{html_start}This account has already been activated.{html_end}')).format(
-                    html_start=HTML('<p class="message-title">'),
-                    html_end=HTML('</p>'),
+                    html_start=HTML('<span class="message-title activation-msgs">'),
+                    html_end=HTML('</span>'),
                 ),
                 extra_tags='account-activation aa-icon',
             )

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -514,7 +514,7 @@ def activate_account(request, key):
             messages.info(
                 request,
                 HTML(_('{html_start}This account has already been activated.{html_end}')).format(
-                    html_start=HTML('<span class="message-title activation-msgs">'),
+                    html_start=HTML('<span class="message-title">'),
                     html_end=HTML('</span>'),
                 ),
                 extra_tags='account-activation aa-icon',

--- a/lms/templates/student_account/form_status.underscore
+++ b/lms/templates/student_account/form_status.underscore
@@ -1,6 +1,5 @@
 <div class="<%- jsHook %> status">
     <div class="message-copy">
-        <%= HtmlUtils.ensureHtml(message) %>
-    </p>
+        <span class="activation-msgs"><%= HtmlUtils.ensureHtml(message) %></span>
+    </div>
 </div>
-

--- a/lms/templates/student_account/form_success.underscore
+++ b/lms/templates/student_account/form_success.underscore
@@ -1,6 +1,6 @@
 <div class="<%- jsHook %> status submission-success">
     <h4 class="message-title"><%- title %></h4>
     <div class="message-copy">
-        <%= HtmlUtils.ensureHtml(messageHtml) %>
+        <span class="activation-msgs"><%= HtmlUtils.ensureHtml(messageHtml) %></span>
     </div>
 </div>


### PR DESCRIPTION
### [PKX-869](https://edlyio.atlassian.net/browse/PKX-869) Used spans instead of p tags

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
