### PR TITLE
PKX-916 VideoQuiz XBlock added in Progress traking list

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1744,6 +1744,10 @@ ADVANCED_PROBLEM_TYPES = [
     {
         'component': 'pakx_completion',
         'boilerplate_name': None
+    },
+    {
+        'component': 'pakx_video_quiz',
+        'boilerplate_name': None
     }
 ]
 

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -208,6 +208,7 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
         'pakx_feedback',
         'pakx_video',
         'pakx_grid_dropdown',
+        'pakx_video_quiz',
         'pakx_completion'
     ]
     all_blocks = get_blocks(

--- a/openedx/features/pakx/lms/overrides/utils.py
+++ b/openedx/features/pakx/lms/overrides/utils.py
@@ -42,7 +42,7 @@ log = getLogger(__name__)
 
 VIDEO_BLOCK_TYPES = ['video', 'pakx_video']
 CORE_BLOCK_TYPES = ['html', 'video', 'problem', 'pakx_video', 'edly_carousel', 'edly_assessment', 'pakx_grid_dropdown']
-PROBLEM_BLOCK_TYPES = ['problem', 'edly_carousel', 'edly_assessment', 'pakx_grid_dropdown']
+PROBLEM_BLOCK_TYPES = ['problem', 'edly_carousel', 'edly_assessment', 'pakx_grid_dropdown', 'pakx_video_quiz']
 BLOCK_TYPES_TO_FILTER = [
     'course', 'chapter', 'sequential', 'vertical', 'discussion', 'openassessment', 'pb-mcq', 'pb-answer', 'pb-choice',
     'pb-message'
@@ -286,6 +286,7 @@ def _accumulate_total_block_counts(total_block_type_counts):
         'edly_carousel': 'problem',
         'pakx_grid_dropdown': 'problem',
         'edly_assessment': 'problem',
+        'pakx_video_quiz': 'problem',
     }
     if total_block_type_counts:
         for block_type, count in total_block_type_counts.items():


### PR DESCRIPTION
### [PKX-916](https://edlyio.atlassian.net/browse/PKX-916) VideoQuiz XBlock added in Progress traking list

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
