### PR TITLE
PKX-982 Integrated ilmX assessment xblock v2 in ilmX

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1748,6 +1748,10 @@ ADVANCED_PROBLEM_TYPES = [
     {
         'component': 'pakx_video_quiz',
         'boilerplate_name': None
+    },
+    {
+        'component': 'pakx_assessment',
+        'boilerplate_name': None
     }
 ]
 

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -200,6 +200,7 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
         'lti_consumer',
         'problem-builder',
         'edly_assessment',
+        'pakx_assessment',
         'edly_kwl',
         'edly_carousel',
         'pakx_flashcard',

--- a/openedx/features/pakx/lms/overrides/utils.py
+++ b/openedx/features/pakx/lms/overrides/utils.py
@@ -41,9 +41,10 @@ from xmodule import course_metadata_utils
 log = getLogger(__name__)
 
 VIDEO_BLOCK_TYPES = ['video', 'pakx_video']
-CORE_BLOCK_TYPES = ['html', 'video', 'problem', 'pakx_video', 'pakx_video_quiz',
+CORE_BLOCK_TYPES = ['html', 'video', 'problem', 'pakx_video', 'pakx_video_quiz', 'pakx_assessment'
                     'edly_carousel', 'edly_assessment', 'pakx_grid_dropdown']
-PROBLEM_BLOCK_TYPES = ['problem', 'edly_carousel', 'edly_assessment', 'pakx_grid_dropdown', 'pakx_video_quiz']
+PROBLEM_BLOCK_TYPES = ['problem', 'edly_carousel', 'edly_assessment', 'pakx_grid_dropdown', 'pakx_video_quiz',
+                       'pakx_assessment']
 BLOCK_TYPES_TO_FILTER = [
     'course', 'chapter', 'sequential', 'vertical', 'discussion', 'openassessment', 'pb-mcq', 'pb-answer', 'pb-choice',
     'pb-message'
@@ -287,6 +288,7 @@ def _accumulate_total_block_counts(total_block_type_counts):
         'edly_carousel': 'problem',
         'pakx_grid_dropdown': 'problem',
         'edly_assessment': 'problem',
+        'pakx_assessment': 'problem',
         'pakx_video_quiz': 'problem',
     }
     if total_block_type_counts:


### PR DESCRIPTION
### [PKX-982](https://edlyio.atlassian.net/browse/PKX-982) Integrated ilmX assessment xblock v2 in ilmX

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
