### PR TITLE
PKX-1076 Added locked units for audit learners

### DIFF
--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -57,6 +57,7 @@ SUPPORTED_FIELDS = [
     SupportedFieldType('video_duration'),
     SupportedFieldType('show_correctness'),
     SupportedFieldType('gated'),
+    SupportedFieldType('show_locked'),
     # 'student_view_data'
     SupportedFieldType(StudentViewTransformer.STUDENT_VIEW_DATA, StudentViewTransformer),
     # 'student_view_multi_device'
@@ -103,6 +104,7 @@ FIELDS_ALLOWED_IN_AUTH_DENIED_CONTENT = [
     "descendants",
     "authorization_denial_reason",
     "authorization_denial_message",
+    "show_locked",
 ]
 
 

--- a/lms/djangoapps/course_blocks/transformers/user_partitions.py
+++ b/lms/djangoapps/course_blocks/transformers/user_partitions.py
@@ -110,7 +110,7 @@ class UserPartitionTransformer(FilteringTransformerMixin, BlockStructureTransfor
             if access_denying_partition:
                 user_group = user_groups.get(access_denying_partition.id)
                 if (
-                    user_group.id == 1
+                    user_group and user_group.id == 1
                     and user_group.name == 'Audit'
                     and isinstance(access_denying_partition, EnrollmentTrackUserPartition)
                 ):

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -234,6 +234,7 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
             'thumbnail_url',
             'video_duration',
             'gated',
+            'show_locked',
         ],
         block_types_filter=block_types_filter,
         allow_start_dates_in_future=allow_start_dates_in_future,

--- a/openedx/features/pakx/lms/overrides/views.py
+++ b/openedx/features/pakx/lms/overrides/views.py
@@ -321,9 +321,12 @@ def _get_course_about_context(request, course_id, category=None):  # pylint: dis
         resume_course_url = None
         has_visited_course = None
         user_progress = 0
+        show_upgrade_after_enrollment = False
         if registered:
             has_visited_course, resume_course_url, _ = get_resume_course_info(request, course_id)
             user_progress = get_course_progress_percentage(request, course_id)
+            enrollment_mode, enrollment_is_active = CourseEnrollment.enrollment_mode_for_user(request.user, course_key)
+            show_upgrade_after_enrollment = enrollment_is_active and enrollment_mode != 'verified' and upgrade_data
         is_course_full = CourseEnrollment.objects.is_course_full(course)
 
         # Register button should be disabled if one of the following is true:
@@ -374,6 +377,7 @@ def _get_course_about_context(request, course_id, category=None):  # pylint: dis
             'ecommerce_bulk_checkout_link': ecommerce_bulk_checkout_link,
             'single_paid_mode': single_paid_mode,
             'upgrade_data': upgrade_data,
+            'show_upgrade_after_enrollment': show_upgrade_after_enrollment,
             'show_courseware_link': show_courseware_link,
             'is_course_full': is_course_full,
             'can_enroll': can_enroll,


### PR DESCRIPTION
### [PKX-1076](https://edlyio.atlassian.net/browse/PKX-1076) Added locked units for audit learners

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
