### PR TITLE
Changed about page URL of 5emodel course for discovery

### DIFF
--- a/openedx/features/pakx/lms/discover/views.py
+++ b/openedx/features/pakx/lms/discover/views.py
@@ -54,6 +54,13 @@ class CourseDataView(APIView):
         course_experience_type = 'VIDEO' if course_custom_setting.course_experience else 'NORMAL'
         pakx_short_logo = '/static/pakx/images/mooc/pakx-logo.png'
 
+        if text_type(course.id) == 'course-v1:LUMSx+2+2022':
+            about_page_url = self.request.build_absolute_uri(reverse('5emodel-course-about'))
+        else:
+            about_page_url = self.request.build_absolute_uri(
+                reverse('about_course', kwargs={'course_id': text_type(course.id)})
+            )
+
         data = {
             'org_name': org_name,
             'course_image_url': self.request.build_absolute_uri(course.course_image_url),
@@ -61,9 +68,7 @@ class CourseDataView(APIView):
             'org_logo_url': self.request.build_absolute_uri(org_logo_url or pakx_short_logo),
             'course_description': course_custom_setting.card_description,
             'course_type': course_experience_type,
-            'about_page_url': self.request.build_absolute_uri(
-                reverse('about_course', kwargs={'course_id': text_type(course.id)})
-            ),
+            'about_page_url': about_page_url,
             'tag': 'Course'
         }
         return self.create_course_card_dict(data, org_logo_url, org_name, course, is_upcoming)

--- a/openedx/features/pakx/lms/overrides/urls.py
+++ b/openedx/features/pakx/lms/overrides/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
     url(r'^partner-with-us/$', PartnerWithUsView.as_view(), name='partner-with-us'),
     url(r'^workplace-essentials-showcase/$', BusinessView.as_view(), name='we-showcase'),
     url(r'^workplace-harassment/$', MarketingCampaignPage.as_view(), name='workplace-harassment'),
-    url(r'^5emodel/signup/$', course_about_static, name='purchase-course'),
+    url(r'^5emodel/signup/$', course_about_static, name='5emodel-course-about'),
     url(r'^basket_check/{}/{}$'.format(
         settings.COURSE_KEY_PATTERN,
         r'(?P<sku>[A-Za-z0-9]+)'


### PR DESCRIPTION
### [PKX-1282](https://edlyio.atlassian.net/browse/PKX-1282) Changed about page URL of 5emodel course for discovery

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[PKX-1282]: https://edlyio.atlassian.net/browse/PKX-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ