### PR TITLE
PKX-1342 User automatic login after sign up

### DIFF
--- a/openedx/features/pakx/lms/discover/views.py
+++ b/openedx/features/pakx/lms/discover/views.py
@@ -24,7 +24,7 @@ from xmodule.modulestore.django import modulestore
 class CourseDataView(APIView):
     """Get course card data."""
 
-    # authentication_classes = [DiscoverAuthentication, ]
+    authentication_classes = [DiscoverAuthentication, ]
 
     @staticmethod
     def get_courses(course_ids):

--- a/openedx/features/pakx/lms/discover/views.py
+++ b/openedx/features/pakx/lms/discover/views.py
@@ -24,7 +24,7 @@ from xmodule.modulestore.django import modulestore
 class CourseDataView(APIView):
     """Get course card data."""
 
-    authentication_classes = [DiscoverAuthentication, ]
+    # authentication_classes = [DiscoverAuthentication, ]
 
     @staticmethod
     def get_courses(course_ids):


### PR DESCRIPTION
### [PKX-1342](https://edlyio.atlassian.net/browse/PKX-1342) User automatic login after sign up

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[PKX-1342]: https://edlyio.atlassian.net/browse/PKX-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ