### PR TITLE
PKX-1433: Add cohort functionality; Disable display of locked content

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -445,8 +445,8 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
         display_items = self.get_display_items()
         locked_page_params = {}
 
-        if len(self.children) != len(display_items):
-            display_items, locked_page_params = self._make_locked_units_for_audit_track(display_items)
+        # if len(self.children) != len(display_items):
+        #     display_items, locked_page_params = self._make_locked_units_for_audit_track(display_items)
 
         self._update_position(context, len(display_items))
 

--- a/lms/djangoapps/course_blocks/transformers/user_partitions.py
+++ b/lms/djangoapps/course_blocks/transformers/user_partitions.py
@@ -109,7 +109,7 @@ class UserPartitionTransformer(FilteringTransformerMixin, BlockStructureTransfor
 
             if access_denying_partition:
                 user_group = user_groups.get(access_denying_partition.id)
-                if (
+                if False and (                          # Forced false to disable show_locked functionality, TO-DO: Add a waffle flag 
                     user_group and user_group.id == 1
                     and user_group.name == 'Audit'
                     and isinstance(access_denying_partition, EnrollmentTrackUserPartition)
@@ -135,8 +135,8 @@ class UserPartitionTransformer(FilteringTransformerMixin, BlockStructureTransfor
                 block_structure.get_transformer_block_field(
                     block_key, self, 'merged_group_access'
                 ).get_access_denying_partition(user_groups) is not None and
-                block_structure.get_xblock_field(block_key, 'authorization_denial_message') is None and
-                block_structure.get_xblock_field(block_key, 'show_locked', default=False) is False
+                block_structure.get_xblock_field(block_key, 'authorization_denial_message') is None
+                # and block_structure.get_xblock_field(block_key, 'show_locked', default=False) is False
             )
         )
         result_list.append(group_access_filter)


### PR DESCRIPTION
### [PKX-1433](https://edlyio.atlassian.net/browse/PKX-1433) Add the Cohort Functionality

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[PKX-1433]: https://edlyio.atlassian.net/browse/PKX-1433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ